### PR TITLE
add tag for kernel elf header retrieval

### DIFF
--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -532,3 +532,15 @@ struct stivale2_struct_tag_dtb {
     uint64_t size;              // The size of the dtb
 } __attribute__((packed));
 ```
+
+#### Elf header (ehdr) tag
+
+This tag reports the address of the elf ehdr loaded by the boot loader. section headers are correctly mapped to their virtual memory addresses
+
+```c
+struct stivale2_struct_elf_header {
+    uint64_t identifier;        // Identifier: 0x656c666865616472
+    uint64_t next;
+    uint64_t addr;              // The address of the elf ehdr
+} __attribute__((packed));
+```

--- a/stivale2.h
+++ b/stivale2.h
@@ -166,4 +166,11 @@ struct stivale2_struct_tag_pxe_server_info {
     uint32_t server_ip;
 } __attribute__((__packed__));
 
+#define STIVALE2_STRUCT_TAG_ELF_HEADER_ID 0x656c666865616472
+
+struct stivale2_struct_tag_elf_ehdr {
+    struct stivale2_tag tag;
+    uint64_t addr;
+} __attribute__((__packed__));
+
 #endif


### PR DESCRIPTION
This would allow the kernel to index the symbol table, and any other table it wants to manipulate, instead of having to include the symtab as a file in an initrd.