### PR TITLE
add tag for kernel elf information passing

### DIFF
--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -538,7 +538,7 @@ struct stivale2_struct_tag_dtb {
 This tag contains a memory copy of the kernel's ELF header
 
 ```c
-struct stivale2_struct_tag_elf_headers {
+struct stivale2_struct_tag_elf_header {
     uint64_t identifier;        // Identifier: b6fc4d84465ec6ee
     uint64_t next;
     uint8_t header[];           // Kernel ELF header

--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -532,3 +532,27 @@ struct stivale2_struct_tag_dtb {
     uint64_t size;              // The size of the dtb
 } __attribute__((packed));
 ```
+
+#### Kernel ELF header tag
+
+This tag contains a memory copy of the kernel's ELF header
+
+```c
+struct stivale2_struct_tag_elf_headers {
+    uint64_t identifier;        // Identifier: b6fc4d84465ec6ee
+    uint64_t next;
+    uint8_t header[];           // Kernel ELF header
+} __attribute__((packed));
+```
+
+#### Kernel ELF section header table
+
+This tag contains a memory copy of the kernel's ELF section header table. All sections present in the table have the sh_addr fields changed to the real memory address of the section specified
+
+```c
+struct stivale2_struct_tag_elf_section_table {
+    uint64_t identifier;        // Identifier: ae8ce59d0119aca5
+    uint64_t next;
+    uint8_t table[];            // Kernel section header table
+} __attribute__((packed));
+```

--- a/stivale2.h
+++ b/stivale2.h
@@ -168,14 +168,14 @@ struct stivale2_struct_tag_pxe_server_info {
 
 #define STIVALE2_STRUCT_TAG_ELF_HEADER_ID 0xb6fc4d84465ec6ee
 
-struct stivale_struct_tag_elf_headers {
+struct stivale2_struct_tag_elf_header {
     struct stivale2_tag tag;
     uint8_t header[];
 } __attribute__((__packed__));
 
 #define STIVALE2_STRUCT_TAG_ELF_SECTION_TABLE_ID 0xae8ce59d0119aca5
 
-struct stivale_struct_tag_elf_section_table {
+struct stivale2_struct_tag_elf_section_table {
     struct stivale2_tag tag;
     uint8_t table[];
 } __attribute__((__packed__));

--- a/stivale2.h
+++ b/stivale2.h
@@ -166,4 +166,18 @@ struct stivale2_struct_tag_pxe_server_info {
     uint32_t server_ip;
 } __attribute__((__packed__));
 
+#define STIVALE2_STRUCT_TAG_ELF_HEADER_ID 0xb6fc4d84465ec6ee
+
+struct stivale_struct_tag_elf_headers {
+    struct stivale2_tag tag;
+    uint8_t header[];
+} __attribute__((__packed__));
+
+#define STIVALE2_STRUCT_TAG_ELF_SECTION_TABLE_ID 0xae8ce59d0119aca5
+
+struct stivale_struct_tag_elf_section_table {
+    struct stivale2_tag tag;
+    uint8_t table[];
+} __attribute__((__packed__));
+
 #endif


### PR DESCRIPTION
because stivale2 only supports elf files, it makes sense that the boot-loader should pass the elf header information without requiring linker hacks or two-stage loaders. these could probably be requested by the tags in the stivale2 header, but I think they should be passed  by default.