### PR TITLE
stivale2: add defines (read info)

### DIFF
--- a/stivale2.h
+++ b/stivale2.h
@@ -135,8 +135,7 @@ struct stivale2_struct_tag_epoch {
 
 #define STIVALE2_STRUCT_TAG_FIRMWARE_ID 0x359d837855e3858c
 
-#define STIVALE2_FIRMWARE_UEFI 0
-#define STIVALE2_FIRMWARE_BIOS 1
+#define STIVALE2_FIRMWARE_BIOS (1 << 0)
 
 struct stivale2_struct_tag_firmware {
     struct stivale2_tag tag;

--- a/stivale2.h
+++ b/stivale2.h
@@ -135,6 +135,9 @@ struct stivale2_struct_tag_epoch {
 
 #define STIVALE2_STRUCT_TAG_FIRMWARE_ID 0x359d837855e3858c
 
+#define STIVALE2_FIRMWARE_UEFI 0
+#define STIVALE2_FIRMWARE_BIOS 1
+
 struct stivale2_struct_tag_firmware {
     struct stivale2_tag tag;
     uint64_t flags;


### PR DESCRIPTION
Since stivale2 tells us that the `uint64_t flags` member in `stivale2_struct_tag_firmware` can be `0` for UEFI or `1` for BIOS, then I decided that it's a good idea to add defines for these two. In a nutshell, defines for `STIVALE2_FIRMWARE_UEFI` and `STIVALE2_FIRMWARE_BIOS` with values `0` and `1`, respectively, added to the file. Code style and naming style are followed.