### PR TITLE
Platform specific ops

### DIFF
--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -1091,3 +1091,32 @@ struct stivale2_struct_vmap {
     uint64_t addr;              // VMAP_HIGH, where the physical memory is mapped in the higher half
 };
 ```
+
+### Platform-specific Functions
+
+This tag provides an abstraction of the platform the kernel is running on
+
+```c
+struct stivale2_struct_platform_ops {
+    struct stivale2_tag tag;
+    void (*map_page)(int proc_id, void (*palloc_align)(size_t size, size_t align), void *phys, void *virt, unsigned int flags); // Maps a page, requires a physical allocator with alignment support
+    void (*unmap_page)(int proc_id, void (*pfree)(void *ptr), void *virt); // Unmaps a page, requires a physical allocator with freeing
+    void *(*get_page)(int proc_id, void *virt); // Obtains a pointer to a page by virtual address
+    void (*set_page)(int proc_id, void *virt, void *new_phys, unsigned int flags); // Sets a page
+    void (*mmu_on)(int proc_id, void (*palloc_align)(size_t size, size_t align)); // Turns the MMU on (requires physical allocator for initial page tables)
+    void (*mmu_off)(int proc_id, void (*pfree)(void *ptr)); // Turns the MMU off
+    void *(*get_va_space)(int proc_id); // Obtains the virtual address space (pointer to root page table)
+    void (*set_va_space)(int proc_id, void *va_space); // Sets the virtual address space
+
+    // On platforms without I/O bound instructions these shall map to MMIO-instructions
+    void (*io_inb)(unsigned int io_addr, uint8_t data); // Character
+    uint8_t (*io_outb)(unsigned int io_addr);
+    void (*io_inw)(unsigned int io_addr, uint16_t data); // Half-word
+    uint16_t (*io_outw)(unsigned int io_addr);
+    void (*io_ind)(unsigned int io_addr, uint32_t data); // Full-word
+    uint32_t (*io_outd)(unsigned int io_addr);
+    void (*io_inq)(unsigned int io_addr, uint64_t data); // Double-word
+    uint64_t (*io_outq)(unsigned int io_addr);
+    uint8_t bits; // Tells the bits the CPU currently has
+};
+```

--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -1098,25 +1098,29 @@ This tag provides an abstraction of the platform the kernel is running on
 
 ```c
 struct stivale2_struct_platform_ops {
-    struct stivale2_tag tag;
-    void (*map_page)(int proc_id, void (*palloc_align)(size_t size, size_t align), void *phys, void *virt, unsigned int flags); // Maps a page, requires a physical allocator with alignment support
-    void (*unmap_page)(int proc_id, void (*pfree)(void *ptr), void *virt); // Unmaps a page, requires a physical allocator with freeing
-    void *(*get_page)(int proc_id, void *virt); // Obtains a pointer to a page by virtual address
-    void (*set_page)(int proc_id, void *virt, void *new_phys, unsigned int flags); // Sets a page
-    void (*mmu_on)(int proc_id, void (*palloc_align)(size_t size, size_t align)); // Turns the MMU on (requires physical allocator for initial page tables)
-    void (*mmu_off)(int proc_id, void (*pfree)(void *ptr)); // Turns the MMU off
-    void *(*get_va_space)(int proc_id); // Obtains the virtual address space (pointer to root page table)
-    void (*set_va_space)(int proc_id, void *va_space); // Sets the virtual address space
+    struct stivale2_tag tag; // Identifier: 0xb0e6b3f8e7e7ca4a
+
+    uint32_t page_size; // Size of a page
+    int (*map_page)(void (*palloc_align)(uint32_t size, uint32_t align), void *phys, void *virt, uint8_t flags); // Maps a page, requires a physical allocator with alignment support
+    int (*unmap_page)(void (*pfree)(void *ptr), void *virt); // Unmaps a page, requires a physical allocator with freeing
+    int *(*get_page)(void *virt); // Obtains a pointer to a page by virtual address
+    int (*set_page)(void *virt, void *new_phys, uint8_t flags); // Sets a page
+    int (*mmu_on)(void (*palloc_align)(size_t size, size_t align)); // Turns the MMU on (requires physical allocator for initial page tables)
+    int (*mmu_off)(void (*pfree)(void *ptr)); // Turns the MMU off
+    int *(*get_va_space)(void); // Obtains the virtual address space (pointer to root page table)
+    int (*set_va_space)(void *va_space); // Sets the virtual address space
+
+    int (*irq_init)(void); // Initialize IRQ table routing
+    int (*irq_set)(void (*handler)(uint64_t id), uint16_t id);
 
     // On platforms without I/O bound instructions these shall map to MMIO-instructions
     void (*io_inb)(unsigned int io_addr, uint8_t data); // Character
-    uint8_t (*io_outb)(unsigned int io_addr);
+    uint8_t (*io_outb)(uint32_t io_addr);
     void (*io_inw)(unsigned int io_addr, uint16_t data); // Half-word
-    uint16_t (*io_outw)(unsigned int io_addr);
-    void (*io_ind)(unsigned int io_addr, uint32_t data); // Full-word
-    uint32_t (*io_outd)(unsigned int io_addr);
-    void (*io_inq)(unsigned int io_addr, uint64_t data); // Double-word
-    uint64_t (*io_outq)(unsigned int io_addr);
-    uint8_t bits; // Tells the bits the CPU currently has
+    uint16_t (*io_outw)(uint32_t io_addr);
+    void (*io_ind)(uint32_t io_addr, uint32_t data); // Full-word
+    uint32_t (*io_outd)(uint32_t io_addr);
+    void (*io_inq)(uint32_t io_addr, uint64_t data); // Double-word
+    uint64_t (*io_outq)(uint32_t io_addr);
 };
 ```

--- a/stivale2.h
+++ b/stivale2.h
@@ -342,24 +342,27 @@ struct stivale2_struct_vmap {
 #ifdef __x86_64__
 #   define STIVALE2_PAGE_READ 1
 #   define STIVALE2_PAGE_WRITE 1
-#   define STIVALE2_PAGE_SIZE 4096
+#   define STIVALE2_PAGE_RDWR (STIVALE2_PAGE_READ | STIVALE2_PAGE_WRITE)
 #else
 #   define STIVALE2_PAGE_READ 0
 #   define STIVALE2_PAGE_WRITE 0
-#   define STIVALE2_PAGE_SIZE 4096
+#   define STIVALE2_PAGE_RDWR 0
 #endif
 
 struct stivale2_struct_platform_ops {
     struct stivale2_tag tag;
-    void (*map_page)(uint8_t proc_id, void (*palloc_align)(uint32_t size, uint32_t align), void *phys, void *virt, uint8_t flags);
-    void (*unmap_page)(uint8_t proc_id, void (*pfree)(void *ptr), void *virt);
-    void *(*get_page)(uint8_t proc_id, void *virt);
-    void (*set_page)(uint8_t proc_id, void *virt, void *new_phys, uint8_t flags);
-    void (*mmu_on)(uint8_t proc_id, void (*palloc_align)(uint32_t size, uint16_t align));
-    void (*mmu_off)(uint8_t proc_id, void (*pfree)(void *ptr));
-    void *(*get_va_space)(uint8_t proc_id);
-    void (*set_va_space)(uint8_t proc_id, void *va_space);
-    void (*io_inb)(uint32_t io_addr, uint8_t data); /* Character */
+    uint32_t page_size;
+    int (*map_page)(void (*palloc_align)(uint32_t size, uint32_t align), void *phys, void *virt, uint8_t flags);
+    int (*unmap_page)(void (*pfree)(void *ptr), void *virt);
+    int *(*get_page)(void *virt);
+    int (*set_page)(void *virt, void *new_phys, uint8_t flags);
+    int (*mmu_on)(void (*palloc_align)(uint32_t size, uint16_t align));
+    int (*mmu_off)(void (*pfree)(void *ptr));
+    int *(*get_va_space)(void);
+    int (*set_va_space)(void *va_space);
+    int (*irq_init)(void);
+    int (*irq_set)(void (*handler)(uint64_t id), uint16_t id);
+    int (*io_inb)(uint32_t io_addr, uint8_t data); /* Character */
     uint8_t (*io_outb)(uint32_t io_addr);
     void (*io_inw)(uint32_t io_addr, uint16_t data); /* Half-word */
     uint16_t (*io_outw)(uint32_t io_addr);
@@ -367,7 +370,6 @@ struct stivale2_struct_platform_ops {
     uint32_t (*io_outd)(uint32_t io_addr);
     void (*io_inq)(uint32_t io_addr, uint64_t data); /* Double-word */
     uint64_t (*io_outq)(uint32_t io_addr);
-    uint8_t bits;
 };
 
 #undef _stivale2_split64

--- a/stivale2.h
+++ b/stivale2.h
@@ -351,22 +351,22 @@ struct stivale2_struct_vmap {
 
 struct stivale2_struct_platform_ops {
     struct stivale2_tag tag;
-    void (*map_page)(int proc_id, void (*palloc_align)(size_t size, size_t align), void *phys, void *virt, unsigned int flags);
-    void (*unmap_page)(int proc_id, void (*pfree)(void *ptr), void *virt);
-    void *(*get_page)(int proc_id, void *virt);
-    void (*set_page)(int proc_id, void *virt, void *new_phys, unsigned int flags);
-    void (*mmu_on)(int proc_id, void (*palloc_align)(size_t size, size_t align));
-    void (*mmu_off)(int proc_id, void (*pfree)(void *ptr));
-    void *(*get_va_space)(int proc_id);
-    void (*set_va_space)(int proc_id, void *va_space);
-    void (*io_inb)(unsigned int io_addr, uint8_t data); /* Character */
-    uint8_t (*io_outb)(unsigned int io_addr);
-    void (*io_inw)(unsigned int io_addr, uint16_t data); /* Half-word */
-    uint16_t (*io_outw)(unsigned int io_addr);
-    void (*io_ind)(unsigned int io_addr, uint32_t data); /* Full-word */
-    uint32_t (*io_outd)(unsigned int io_addr);
-    void (*io_inq)(unsigned int io_addr, uint64_t data); /* Double-word */
-    uint64_t (*io_outq)(unsigned int io_addr);
+    void (*map_page)(uint8_t proc_id, void (*palloc_align)(uint32_t size, uint32_t align), void *phys, void *virt, uint8_t flags);
+    void (*unmap_page)(uint8_t proc_id, void (*pfree)(void *ptr), void *virt);
+    void *(*get_page)(uint8_t proc_id, void *virt);
+    void (*set_page)(uint8_t proc_id, void *virt, void *new_phys, uint8_t flags);
+    void (*mmu_on)(uint8_t proc_id, void (*palloc_align)(uint32_t size, uint16_t align));
+    void (*mmu_off)(uint8_t proc_id, void (*pfree)(void *ptr));
+    void *(*get_va_space)(uint8_t proc_id);
+    void (*set_va_space)(uint8_t proc_id, void *va_space);
+    void (*io_inb)(uint32_t io_addr, uint8_t data); /* Character */
+    uint8_t (*io_outb)(uint32_t io_addr);
+    void (*io_inw)(uint32_t io_addr, uint16_t data); /* Half-word */
+    uint16_t (*io_outw)(uint32_t io_addr);
+    void (*io_ind)(uint32_t io_addr, uint32_t data); /* Full-word */
+    uint32_t (*io_outd)(uint32_t io_addr);
+    void (*io_inq)(uint32_t io_addr, uint64_t data); /* Double-word */
+    uint64_t (*io_outq)(uint32_t io_addr);
     uint8_t bits;
 };
 

--- a/stivale2.h
+++ b/stivale2.h
@@ -336,6 +336,40 @@ struct stivale2_struct_vmap {
     uint64_t addr;
 };
 
+#define STIVALE2_STRUCT_TAG_PLATFORM_OPS 0xb0e6b3f8e7e7ca4a
+
+/* Platform-specifics - etc */
+#ifdef __x86_64__
+#   define STIVALE2_PAGE_READ 1
+#   define STIVALE2_PAGE_WRITE 1
+#   define STIVALE2_PAGE_SIZE 4096
+#else
+#   define STIVALE2_PAGE_READ 0
+#   define STIVALE2_PAGE_WRITE 0
+#   define STIVALE2_PAGE_SIZE 4096
+#endif
+
+struct stivale2_struct_platform_ops {
+    struct stivale2_tag tag;
+    void (*map_page)(int proc_id, void (*palloc_align)(size_t size, size_t align), void *phys, void *virt, unsigned int flags);
+    void (*unmap_page)(int proc_id, void (*pfree)(void *ptr), void *virt);
+    void *(*get_page)(int proc_id, void *virt);
+    void (*set_page)(int proc_id, void *virt, void *new_phys, unsigned int flags);
+    void (*mmu_on)(int proc_id, void (*palloc_align)(size_t size, size_t align));
+    void (*mmu_off)(int proc_id, void (*pfree)(void *ptr));
+    void *(*get_va_space)(int proc_id);
+    void (*set_va_space)(int proc_id, void *va_space);
+    void (*io_inb)(unsigned int io_addr, uint8_t data); /* Character */
+    uint8_t (*io_outb)(unsigned int io_addr);
+    void (*io_inw)(unsigned int io_addr, uint16_t data); /* Half-word */
+    uint16_t (*io_outw)(unsigned int io_addr);
+    void (*io_ind)(unsigned int io_addr, uint32_t data); /* Full-word */
+    uint32_t (*io_outd)(unsigned int io_addr);
+    void (*io_inq)(unsigned int io_addr, uint64_t data); /* Double-word */
+    uint64_t (*io_outq)(unsigned int io_addr);
+    uint8_t bits;
+};
+
 #undef _stivale2_split64
 
 #endif


### PR DESCRIPTION
The main idea is basically that kernels can be portable without much hassle - to any platform - provided that the boot-loader implementation provides ops for abstracting the platform the kernel is running on.

So the work of allocating and managing the resources is given to the kernel, but the boot-loader would help the kernel to have a better portability.

This would lower the entry barrier for many non-x86 platforms and OS development in general.

However i don't know if this may align with the philosophy of stivale2. So here i am, making this PR.