### PR TITLE
Tag-less mode

### DIFF
--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -62,6 +62,26 @@ struct stivale2_anchor {
 
 Anchored kernels are otherwise functionally equivalent to ELF counterparts.
 
+## Tag-less mode
+In a bootloader-defined way, the kernel may communicate to the bootloader that this
+kernel is a _tag-less_ stivale2 kernel. This indicates that the kernel does not contain
+a stivale2 header, but it should be assumed these defaults are set:
+ - The entrypoint value is set to the ELF entrypoint.
+ - The stack is allocated by the bootloader and is 16K, and is mapped at:
+  1. 0xffff900000000000 (4-level paging)
+  2. 0xff00100000000000 (5-level paging)
+  3. vmap_high + 0x0000100000000000 (non-x86 architectures)
+ - The flags are set as following:
+  0. KASLR is disabled
+  1. Higher-half pointers: If the entrypoint's most significat bit of e_entry in the ELF header is set.
+  2. Protected memory ranges: Enabled
+ - The bootloader should assume the following tags:
+  0. The any video header tag, asking for a graphical framebuffer.
+  1. The terminal header tag.
+  2. The unmap null header tag.
+  3. The SMP header tag, without the x2apic flag and with the SMP stack allocation flag.
+};
+
 ## Kernel entry machine state
 
 ### x86_64
@@ -457,6 +477,7 @@ struct stivale2_header_tag_smp {
     uint64_t next;
     uint64_t flags;               // Flags:
                                   //   bit 0: 0 = use xAPIC, 1 = use x2APIC (if available)
+                                  //   bit 1: if set, allocates a stack of 16K for all cores automatically
                                   // All other bits are undefined and must be 0.
 };
 ```

--- a/STIVALE2.md
+++ b/STIVALE2.md
@@ -67,19 +67,16 @@ In a bootloader-defined way, the kernel may communicate to the bootloader that t
 kernel is a _tag-less_ stivale2 kernel. This indicates that the kernel does not contain
 a stivale2 header, but it should be assumed these defaults are set:
  - The entrypoint value is set to the ELF entrypoint.
- - The stack is allocated by the bootloader and is 16K, and is mapped at:
-  1. 0xffff900000000000 (4-level paging)
-  2. 0xff00100000000000 (5-level paging)
-  3. vmap_high + 0x0000100000000000 (non-x86 architectures)
+ - The stack is allocated by the bootloader and is 16K, and is mapped at a bootloader-defined address, with the stipulation that the half it is in must be the same as the half the kernel entrypoint is in
  - The flags are set as following:
-  0. KASLR is disabled
-  1. Higher-half pointers: If the entrypoint's most significat bit of e_entry in the ELF header is set.
-  2. Protected memory ranges: Enabled
+    1. KASLR is disabled
+    2. Higher-half pointers: If the entrypoint's most significat bit of e_entry in the ELF header is set.
+    3. Protected memory ranges: Enabled
  - The bootloader should assume the following tags:
-  0. The any video header tag, asking for a graphical framebuffer.
-  1. The terminal header tag.
-  2. The unmap null header tag.
-  3. The SMP header tag, without the x2apic flag and with the SMP stack allocation flag.
+    1. The any video header tag, asking for a graphical framebuffer.
+    2. The terminal header tag.
+    3. The unmap null header tag.
+    4. The SMP header tag, without the x2apic flag and with the SMP stack allocation flag.
 };
 
 ## Kernel entry machine state


### PR DESCRIPTION
This pr adds so-called tag-less mode, which, in a bootloader-specific manner (in limine an env var or a special proto) allows the kernel to not have any special headers. It is meant for quick prototyping when you don't want to write a lot of config.